### PR TITLE
Change babel plugin array to correct format

### DIFF
--- a/lib/App/loadScript.js
+++ b/lib/App/loadScript.js
@@ -15,23 +15,23 @@ const uglifyJSOptions = {
 
 const babelOptions = {
 	plugins: [
-		require('babel-plugin-transform-es2015-template-literals'),
-		require('babel-plugin-transform-es2015-literals'),
-		require('babel-plugin-transform-es2015-function-name'),
-		require('babel-plugin-transform-es2015-arrow-functions'),
-		require('babel-plugin-transform-es2015-block-scoped-functions'),
-		require('babel-plugin-transform-es2015-classes'),
-		require('babel-plugin-transform-es2015-object-super'),
-		require('babel-plugin-transform-es2015-shorthand-properties'),
-		require('babel-plugin-transform-es2015-computed-properties'),
-		require('babel-plugin-transform-es2015-for-of'),
-		require('babel-plugin-transform-es2015-sticky-regex'),
-		require('babel-plugin-transform-es2015-unicode-regex'),
-		require('babel-plugin-check-es2015-constants'),
-		require('babel-plugin-transform-es2015-spread'),
-		require('babel-plugin-transform-es2015-parameters'),
-		require('babel-plugin-transform-es2015-destructuring'),
-		require('babel-plugin-transform-es2015-block-scoping')
+		'babel-plugin-transform-es2015-template-literals',
+		'babel-plugin-transform-es2015-literals',
+		'babel-plugin-transform-es2015-function-name',
+		'babel-plugin-transform-es2015-arrow-functions',
+		'babel-plugin-transform-es2015-block-scoped-functions',
+		'babel-plugin-transform-es2015-classes',
+		'babel-plugin-transform-es2015-object-super',
+		'babel-plugin-transform-es2015-shorthand-properties',
+		'babel-plugin-transform-es2015-computed-properties',
+		'babel-plugin-transform-es2015-for-of',
+		'babel-plugin-transform-es2015-sticky-regex',
+		'babel-plugin-transform-es2015-unicode-regex',
+		'babel-plugin-check-es2015-constants',
+		'babel-plugin-transform-es2015-spread',
+		'babel-plugin-transform-es2015-parameters',
+		'babel-plugin-transform-es2015-destructuring',
+		'babel-plugin-transform-es2015-block-scoping'
 	]
 }
 
@@ -56,7 +56,7 @@ module.exports = function*(file) {
 
 	try {
 		let cached = this.cache.scripts[file]
-		
+
 		if(cached && (yield fs.statAsync(file)).mtime <= new Date(cached.mtime))
 			return cached.code
 


### PR DESCRIPTION
I've had some issues installing aero on my Centos 7 server because he was not able to find the babel-plugin-transform-es2015-* modules. 

In order to fix it i've corrected the format of the array containing the plugins, according to http://babeljs.io/docs/plugins/transform-es2015-arrow-functions#via-node-api