### PR TITLE
Fixing a missing parameter who crashes Aero when loading static pages…

### DIFF
--- a/lib/App/routePage.js
+++ b/lib/App/routePage.js
@@ -72,7 +72,7 @@ const respondStatic = function(code, baseHeaders) {
 		const gzippedCode = zlib.gzipSync(code, bestCompressionOptions)
 
 		headers['Content-Length'] = gzippedCode.length
-		headers.ETag = xxhash.hash(Buffer.from(gzippedCode)).toString()
+		headers.ETag = xxhash.hash(Buffer.from(gzippedCode), 0).toString()
 
 		return function(request, response) {
 			if(request.headers['if-none-match'] === headers.ETag) {


### PR DESCRIPTION
… over the threshold value

My first solution was to increase the Threshold to avoid the use of Gzip, and after checking the 		headers.ETag = xxhash.hash(Buffer.from(gzippedCode)).toString() who returned an error, I checked the xxhash documentation, and I saw it was a missing parameter who gets static pages to crash.

Enjoy 💜
