### PR TITLE
minifyScripts.js not supported uglify-es options fix

### DIFF
--- a/lib/App/minifyScripts.js
+++ b/lib/App/minifyScripts.js
@@ -1,13 +1,7 @@
 const uglifyJS = require('uglify-es')
 
 const uglifyJSOptions = {
-	fromString: true,
-	compress: {
-		screw_ie8: true
-	},
-	mangle: {
-		screw_ie8: true
-	}
+	ie8: false
 }
 
 let minify = function(source, file) {


### PR DESCRIPTION
https://github.com/aurelia/cli/issues/636

All not .min.js scripts files was not loaded 